### PR TITLE
Added ability to provide content descriptions for back, forward and refresh buttons

### DIFF
--- a/extendedbrowser-sample/src/main/java/com/robotsandpencils/extendedbrowsersample/MainActivity.java
+++ b/extendedbrowser-sample/src/main/java/com/robotsandpencils/extendedbrowsersample/MainActivity.java
@@ -24,6 +24,9 @@ public class MainActivity extends AppCompatActivity {
         mBinding = DataBindingUtil.setContentView(this, R.layout.activity_main);
 
         mBinding.webViewBrowser.attachDefaultWebViewClient();
+        mBinding.webViewBrowser.setBackButtonDescription(getString(R.string.back_button_description));
+        mBinding.webViewBrowser.setForwardButtonDescription(getString(R.string.forward_button_description));
+        mBinding.webViewBrowser.setRefreshButtonDescription(getString(R.string.refresh_button_description));
 
         mBinding.toggleAddressBar.setOnClickListener(new View.OnClickListener() {
             @Override

--- a/extendedbrowser-sample/src/main/res/values/strings.xml
+++ b/extendedbrowser-sample/src/main/res/values/strings.xml
@@ -7,4 +7,7 @@
 
 <resources>
     <string name="app_name">ExtendedBrowserSample</string>
+    <string name="back_button_description">Back</string>
+    <string name="forward_button_description">Forward</string>
+    <string name="refresh_button_description">Refresh</string>
 </resources>

--- a/extendedbrowser/build.gradle
+++ b/extendedbrowser/build.gradle
@@ -20,7 +20,7 @@ ext {
     siteUrl = 'https://github.com/RobotsAndPencils/ExtendedBrowser'
     gitUrl = 'https://github.com/RobotsAndPencils/ExtendedBrowser.git'
 
-    libraryVersion = '0.0.5'
+    libraryVersion = '0.0.6'
 
     developerId = 'android'
     developerName = 'Robots & Pencils Android Team'

--- a/extendedbrowser/src/main/java/com/robotsandpencils/extendedbrowser/viewmodels/ExtendedBrowserViewModel.java
+++ b/extendedbrowser/src/main/java/com/robotsandpencils/extendedbrowser/viewmodels/ExtendedBrowserViewModel.java
@@ -14,13 +14,16 @@ import com.robotsandpencils.extendedbrowser.BR;
 
 /**
  * ViewModel class for handling two-way data binding
- * <p>
+ *
  * Created by farhankhan on 2016-07-13.
  */
 public class ExtendedBrowserViewModel extends BaseObservable {
     private boolean showNavigationBar;
     private String addressBarUrl;
     private boolean showAddressBar;
+    private String backButtonDescription;
+    private String forwardButtonDescription;
+    private String refreshButtonDescription;
 
     @Bindable
     public boolean isNavigationBarShowing() {
@@ -49,9 +52,43 @@ public class ExtendedBrowserViewModel extends BaseObservable {
         return addressBarUrl;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public ExtendedBrowserViewModel setAddressBarUrl(String addressBarUrl) {
         this.addressBarUrl = addressBarUrl;
         notifyPropertyChanged(BR.addressBarUrl);
+        return this;
+    }
+
+    @Bindable
+    public String getBackButtonDescription() {
+        return backButtonDescription;
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public ExtendedBrowserViewModel setBackButtonDescription(String backButtonDescription) {
+        this.backButtonDescription = backButtonDescription;
+        return this;
+    }
+
+    @Bindable
+    public String getForwardButtonDescription() {
+        return forwardButtonDescription;
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public ExtendedBrowserViewModel setForwardButtonDescription(String forwardButtonDescription) {
+        this.forwardButtonDescription = forwardButtonDescription;
+        return this;
+    }
+
+    @Bindable
+    public String getRefreshButtonDescription() {
+        return refreshButtonDescription;
+    }
+
+    @SuppressWarnings("UnusedReturnValue")
+    public ExtendedBrowserViewModel setRefreshButtonDescription(String refreshButtonDescription) {
+        this.refreshButtonDescription = refreshButtonDescription;
         return this;
     }
 }

--- a/extendedbrowser/src/main/java/com/robotsandpencils/extendedbrowser/views/ExtendedBrowser.java
+++ b/extendedbrowser/src/main/java/com/robotsandpencils/extendedbrowser/views/ExtendedBrowser.java
@@ -84,9 +84,9 @@ public class ExtendedBrowser extends RelativeLayout {
 
     @SuppressLint("SetJavaScriptEnabled")
     private void init(Context context, AttributeSet attrs) {
-        int id = 0;
-        boolean showNavigationBar = false;
-        boolean showAddressBar = false;
+        int id;
+        boolean showNavigationBar;
+        boolean showAddressBar;
 
         mBinding = ExtendedBrowserBinding.inflate((LayoutInflater) getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE),
                 this, true);
@@ -103,9 +103,11 @@ public class ExtendedBrowser extends RelativeLayout {
             return;
         }
 
-        mViewModel = new ExtendedBrowserViewModel().showNavigationBar(showNavigationBar).showAddressBar(showAddressBar);
+        mViewModel = new ExtendedBrowserViewModel()
+                .showNavigationBar(showNavigationBar)
+                .showAddressBar(showAddressBar);
 
-        mProgressBar = (ProgressBar) findViewById(id);
+        mProgressBar = findViewById(id);
         mBinding.navigationReload.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -162,14 +164,11 @@ public class ExtendedBrowser extends RelativeLayout {
         }
 
         // enable pinch zoom
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
-            webView.getSettings().setBuiltInZoomControls(true);
-            webView.getSettings().setDisplayZoomControls(false);
-        }
+        webView.getSettings().setBuiltInZoomControls(true);
+        webView.getSettings().setDisplayZoomControls(false);
 
         // enable javascript
         webView.getSettings().setJavaScriptEnabled(true);
-        //_webView.getSettings().setJavaScriptCanOpenWindowsAutomatically(true);
 
         // enable html5 local storage
         webView.getSettings().setDomStorageEnabled(true);
@@ -190,6 +189,7 @@ public class ExtendedBrowser extends RelativeLayout {
      *
      * @param listener OnBackNotAvailableListener
      */
+    @SuppressWarnings("unused")
     public void setOnBackNotAvailableListener(OnBackNotAvailableListener listener) {
         mOnBackNotAvailableListener = listener;
     }
@@ -208,6 +208,7 @@ public class ExtendedBrowser extends RelativeLayout {
      *
      * @return EditText
      */
+    @SuppressWarnings("unused")
     public EditText getAddressBarView() {
         return mBinding.addressBarView;
     }
@@ -215,7 +216,7 @@ public class ExtendedBrowser extends RelativeLayout {
     /**
      * Show/hide address bar
      *
-     * @param showAddressBar
+     * @param showAddressBar boolean
      */
     public void showAddressBar(boolean showAddressBar) {
         mViewModel.showAddressBar(showAddressBar);
@@ -253,6 +254,7 @@ public class ExtendedBrowser extends RelativeLayout {
      *
      * @param url String
      */
+    @SuppressWarnings("unused")
     public void setAddressBarUrl(String url) {
         mViewModel.setAddressBarUrl(url);
     }
@@ -263,6 +265,7 @@ public class ExtendedBrowser extends RelativeLayout {
      * @param url     String
      * @param loadUrl boolean Set to true if you want the url to load in a browser
      */
+    @SuppressWarnings("SameParameterValue")
     public void setAddressBarUrl(String url, boolean loadUrl) {
         mViewModel.setAddressBarUrl(url);
         if (loadUrl) {
@@ -282,7 +285,38 @@ public class ExtendedBrowser extends RelativeLayout {
      *
      * @param client WebViewClient
      */
+    @SuppressWarnings("unused")
     public void setWebViewClient(WebViewClient client) {
         mBinding.nativeWebView.setWebViewClient(client);
+    }
+
+    /**
+     * Set back button description for accessibility
+     *
+     * @param backButtonDescription String
+     */
+    @SuppressWarnings("unused")
+    public void setBackButtonDescription(String backButtonDescription) {
+        mViewModel.setBackButtonDescription(backButtonDescription);
+    }
+
+    /**
+     * Set forward button description for accessibility
+     *
+     * @param forwardButtonDescription String
+     */
+    @SuppressWarnings("unused")
+    public void setForwardButtonDescription(String forwardButtonDescription) {
+        mViewModel.setForwardButtonDescription(forwardButtonDescription);
+    }
+
+    /**
+     * Set refresh button description for accessibility
+     *
+     * @param refreshButtonDescription String
+     */
+    @SuppressWarnings("unused")
+    public void setRefreshButtonDescription(String refreshButtonDescription) {
+        mViewModel.setRefreshButtonDescription(refreshButtonDescription);
     }
 }

--- a/extendedbrowser/src/main/res/layout/extended_browser.xml
+++ b/extendedbrowser/src/main/res/layout/extended_browser.xml
@@ -59,8 +59,8 @@
                     android:background="?android:attr/selectableItemBackground"
                     android:padding="@dimen/web_navigation_view_padding"
                     android:src="@drawable/nav_button_back_src_selector"
-                    tools:ignore="ContentDescription"
-                    tools:targetApi="honeycomb"/>
+                    tools:targetApi="honeycomb"
+                    android:contentDescription="@{viewModel.backButtonDescription}"/>
 
                 <ImageButton
                     android:id="@+id/navigation_right"
@@ -74,7 +74,7 @@
                     android:background="?android:attr/selectableItemBackground"
                     android:padding="@dimen/web_navigation_view_padding"
                     android:src="@drawable/nav_button_forward_src_selector"
-                    tools:ignore="ContentDescription"/>
+                    android:contentDescription="@{viewModel.forwardButtonDescription}"/>
 
                 <ImageButton
                     android:id="@+id/navigation_reload"
@@ -86,7 +86,8 @@
                     android:background="?android:attr/selectableItemBackground"
                     android:padding="@dimen/web_navigation_view_padding"
                     android:src="@drawable/icon_refresh_browser"
-                    tools:ignore="ContentDescription,NewApi"/>
+                    android:contentDescription="@{viewModel.refreshButtonDescription}"
+                    tools:ignore="NewApi"/>
 
             </RelativeLayout>
 


### PR DESCRIPTION
How to test:
1. Activate Talkback
2. Run ExtendedBrowserSample
3. Tap on Back, Forward and Refresh buttons to ensure they have proper descriptions.